### PR TITLE
Fix wrong request mode

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -167,7 +167,7 @@ class DroneClient {
         Joi.assert(name, Joi.string().required(), 'Must specify name');
         Joi.assert(num, Joi.number().required(), 'Must specify num');
         Joi.assert(job, Joi.number().required(), 'Must specify job');
-        return this._request('post', `/api/repos/${owner}/${name}/builds/${num}/${job}`);
+        return this._request('delete', `/api/repos/${owner}/${name}/builds/${num}/${job}`);
     };
 
     forkBuild(owner, name, num) {


### PR DESCRIPTION
As per the Drone server routes, https://github.com/drone/drone/blob/master/router/router.go#L105, it should be using `DELETE`