### PR TITLE
Add deprecation message & link to drone-js repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # drone-node
 Node client for the Drone API
 
+## Deprecated
+
+**Note:** This repo is deprecated and is not receiving updates.  Please visit the new [drone-js repo](https://github.com/drone/drone-js)
+
 ## Client
 
 An API client is included in this package


### PR DESCRIPTION
Seems this repo is not being maintained but a new drone-js lib has taken over.  Since the drone-node repo is still linked from http://readme.drone.io/api/api-overview/ it would be helpful to point people to the right place.