### PR TITLE
Return objects from client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,10 @@ class Client {
         Authorization: `Bearer ${config.token}`
       }
     })
+    this._axios.interceptors.response.use(
+      response => response.data,
+      error => Promise.reject(error.toJSON())
+    )
   }
 
   /**

--- a/test/client.js
+++ b/test/client.js
@@ -13,25 +13,87 @@ const client = new Drone.Client({
   token: process.env.DRONE_TOKEN
 })
 
-it('can get the current user', (done) => {
-  client.getSelf().then((res) => {
-    expect(res).to.be.an.object()
+it('can get the current user', async () => {
+  const res = await client.getSelf()
+  expect(res).to.be.an.object()
+  expect(res).to.contain([
+    'id',
+    'login',
+    'email',
+    'machine',
+    'admin',
+    'active',
+    'avatar',
+    'syncing',
+    'synced',
+    'created',
+    'updated',
+    'last_login'
+  ])
+})
 
-    expect(res).to.contain([
-      'id',
-      'login',
-      'email',
-      'machine',
-      'admin',
-      'active',
-      'avatar',
-      'syncing',
-      'synced',
-      'created',
-      'updated',
-      'last_login'
-    ])
-
-    return done()
-  }).catch(done)
+it('can get recent builds', async () => {
+  const res = await client.recentBuilds()
+  expect(res).to.be.an.array()
+  if (res.length) {
+    res.forEach(r => {
+      expect(r).to.contain([
+        'id',
+        'uid',
+        'user_id',
+        'namespace',
+        'name',
+        'slug',
+        'scm',
+        'git_http_url',
+        'git_ssh_url',
+        'link',
+        'default_branch',
+        'private',
+        'visibility',
+        'active',
+        'config_path',
+        'trusted',
+        'protected',
+        'ignore_forks',
+        'ignore_pull_requests',
+        'auto_cancel_pull_requests',
+        'auto_cancel_pushes',
+        'timeout',
+        'counter',
+        'synced',
+        'created',
+        'updated',
+        'version'
+      ])
+      expect(r.build).to.contain([
+        'id',
+        'repo_id',
+        'trigger',
+        'number',
+        'status',
+        'event',
+        'action',
+        'link',
+        'timestamp',
+        'message',
+        'before',
+        'after',
+        'ref',
+        'source_repo',
+        'source',
+        'target',
+        'author_login',
+        'author_name',
+        'author_email',
+        'author_avatar',
+        'sender',
+        'started',
+        'finished',
+        'created',
+        'updated',
+        'version'
+      ])
+    })
+  }
 })


### PR DESCRIPTION
Resolves #16 

Adds a middleware that will only return the data from the requests. For errors, the entire error is returned but this could be changed to only include fields like the message and stack.

I also fixed the unit tests as they were never getting into the then function to verify the shape of the data being returned. 