### PR TITLE
Pass parameters to promote/rollback as querystring

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -328,14 +328,14 @@ class Client {
     Joi.assert(target, Joi.string().required(), 'Must specify target')
     Joi.assert(params, Joi.object().pattern(/.*/, Joi.string()), 'Specify valid params')
 
+    const qs = Querystring.stringify(
+      Object.assign(
+        { target: target },
+        params
+      )
+    )
     return this._axios.post(
-            `/api/repos/${owner}/${repo}/builds/${number}/promote`,
-            Querystring.stringify(
-              Object.assign(
-                { target: target },
-                params
-              )
-            )
+            `/api/repos/${owner}/${repo}/builds/${number}/promote?${qs}`
     )
   }
 
@@ -354,14 +354,14 @@ class Client {
     Joi.assert(target, Joi.string().required(), 'Must specify target')
     Joi.assert(params, Joi.object().pattern(/.*/, Joi.string()), 'Specify valid params')
 
+    const qs = Querystring.stringify(
+      Object.assign(
+        { target: target },
+        params
+      )
+    )
     return this._axios.post(
-            `/api/repos/${owner}/${repo}/builds/${number}/rollback`,
-            Querystring.stringify(
-              Object.assign(
-                { target: target },
-                params
-              )
-            )
+            `/api/repos/${owner}/${repo}/builds/${number}/rollback/${qs}`
     )
   }
 


### PR DESCRIPTION
Custom build params are ignored when sent on the POST body and need to be attached to the querystring. Modify the promote and rollback functions to ensure that the params are sent in a way that is recognised by the Drone server.