### PR TITLE
Add pages to builds query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,14 +216,20 @@ class Client {
    * Get builds
    * @param {string} owner Owner of the repo
    * @param {string} repo Name of the repo
+   * @param {integer} page Page number
+   * @param {integer} limit Page limit
    */
-  getBuilds (owner, repo) {
+  getBuilds (owner, repo, page=1, limit = 25) {
     Joi.assert(owner, Joi.string().required(), 'Must specify owner')
     Joi.assert(repo, Joi.string().required(), 'Must specify repo')
 
     return this._axios.get(
-            `/api/repos/${owner}/${repo}/builds`
-    )
+      `/api/repos/${owner}/${repo}/builds`,{
+        params: {
+          page: page,
+          per_page: limit
+        }
+      })
   }
 
   /**


### PR DESCRIPTION
It appears that there is no way to get the pages for builds. This exists for the golang lib though so I'm going to see if it works. I assume it does. :sweat_smile: 