### PR TITLE
Fix promote and rollback commands to pass params as query string params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -342,13 +342,9 @@ class Client {
     Joi.assert(params, Joi.object().pattern(/.*/, Joi.string()), 'Specify valid params')
 
     return this._axios.post(
-            `/api/repos/${owner}/${repo}/builds/${number}/promote`,
-            Querystring.stringify(
-              Object.assign(
-                { target: target },
-                params
-              )
-            )
+      `/api/repos/${owner}/${repo}/builds/${number}/promote`,
+      undefined,
+      { params: Object.assign({ target: target }, params) }
     )
   }
 
@@ -427,7 +423,8 @@ class Client {
 
     return this._axios.post(
             `/api/repos/${owner}/${repo}/builds`,
-            Querystring.stringify(params)
+            undefined,
+            { params: params }
     )
   }
 


### PR DESCRIPTION
This fixes a bug in which the params for the promote and rollback operations were being passed to the api via the body instead of as [query string params](https://docs.drone.io/api/builds/build_promote/). 

Reviewing with the [`axios` docs](https://github.com/axios/axios/tree/v0.26.1?tab=readme-ov-file#axiosposturl-data-config-1), it looks like for `POST` requests the params are passed as the 3rd argument.